### PR TITLE
fix(strict-color-code) Add strict validation for hex codes

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -111,7 +111,7 @@ module.exports = class WebpackGenerator extends Generator {
 						name: 'themeColor',
 						type: 'input',
 						validate: value => {
-							const pattern = /#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})/i;
+							const pattern = /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i;
 							if(pattern.test(value)) {
 								return true;
 							} else {


### PR DESCRIPTION
It would fix [Issue#30](https://github.com/sendilkumarn/webpack-scaffold-pwa/issues/30)