### PR TITLE
fix(dependencies): Move @webpack-cli/webpack-scaffold under dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "test": "ava --verbose"
   },
   "dependencies": {
+    "@webpack-cli/webpack-scaffold": "^0.1.0",
     "cross-spawn": "^6.0.5",
     "yeoman-generator": "^2.0.2"
   },
   "devDependencies": {
-    "@webpack-cli/webpack-scaffold": "^0.1.0",
     "ava": "^1.0.0-beta.3",
     "babel-eslint": "^8.2.1",
     "eslint": "^4.18.1"


### PR DESCRIPTION
@sendilkumarn `@webpack-cli/webpack-scaffold` is required in runtime
so shifted it to dependencies from devDependencies